### PR TITLE
fix: sjra-1350 Change JAVA to version 17

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'maven'
 
       - name: Extract version from tag

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'maven'
 
       - name: Run unit tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Custom Java UDFs for [StarRocks](https://starrocks.io/), focused on genomics data transformation. Currently contains `VariantIdUDF`, which encodes genomic variants (SNV, deletion, micro-insertion) into 64-bit signed integers using bit-packing.
+
+## Build Commands
+
+```bash
+mvn test                    # Run all tests
+mvn package                 # Build fat JAR (includes tests)
+mvn package -DskipTests     # Build fat JAR without tests
+mvn clean test              # Clean build + test
+```
+
+Output JAR: `target/radiant-starrocks-udf-<version>-jar-with-dependencies.jar`
+
+## Architecture
+
+- **Java 17**, Maven build, no runtime dependencies (standalone fat JAR for StarRocks)
+- **Single UDF pattern**: Each UDF class lives in `src/main/java/org/radiant/` and exposes a `public Long evaluate(...)` method that StarRocks calls directly
+- **Tests**: JUnit 5 in `src/test/java/org/radiant/`, one test class per UDF
+
+### VariantIdUDF Encoding (63 useful bits + MSB flag)
+
+```
+| MSB=1 | chrom (5 bits) | start (30 bits) | alt (3 bits) | length (25 bits) |
+```
+
+- Chromosomes: 1-22 numeric, X→23, Y→24, M/MT→25
+- Returns `null` for any invalid or unsupported input (insertions >1bp, MNVs)
+
+## CI/CD
+
+- **PRs to main**: `test.yml` runs `mvn test` + builds the fat JAR
+- **Tags `v*`**: `deploy.yml` sets POM version from tag, tests, builds, deploys to GitHub Packages, and creates a GitHub Release with the fat JAR attached
+
+## Releasing
+
+```bash
+git tag v1.0.1
+git push origin v1.0.1    # Triggers deploy workflow
+```

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
 
     <groupId>org.radiant</groupId>
     <artifactId>radiant-starrocks-udf</artifactId>
-    <version>1.0.0</version>
+    <version>1.2.0</version>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>

--- a/src/main/java/org/radiant/VariantIdUDF.java
+++ b/src/main/java/org/radiant/VariantIdUDF.java
@@ -76,17 +76,12 @@ public class VariantIdUDF {
     }
 
     private int baseCode(char base) {
-        switch (base) {
-            case 'A':
-                return 1;
-            case 'T':
-                return 2;
-            case 'C':
-                return 3;
-            case 'G':
-                return 4;
-            default:
-                return -1;
-        }
+        return switch (Character.toUpperCase(base)) {
+            case 'A' -> 1;
+            case 'T' -> 2;
+            case 'C' -> 3;
+            case 'G' -> 4;
+            default -> -1;
+        };
     }
 }


### PR DESCRIPTION
## 📌 Context

<!-- Briefly describe the purpose of this PR. Include any relevant context. -->

With the updated StarRocks cluster, the JAVA version has changed. We need to compile the UDFs with the appropriate JAVA version. 

## 📝 Changes

<!-- List the main changes in this PR. -->

- Add support for JAVA version 17 and remove support for JAVA version 11 (see note for legacy)

## 🧪 Tests

<!-- Describe any new or updated tests, how to run them, and relevant results. -->

- No additional test ran, but validated `mvn clean package` does not fail. 

## 🔗 Related Issues

<!-- Link to any relevant GitHub issues, Jira tickets, etc. -->

- https://d3b.atlassian.net/browse/SJRA-1350

## 👀 Notes for Reviewers

<!-- Anything reviewers should pay special attention to. Questions, caveats, tricky parts, etc. -->

- The previous releases are still available in the Github packages in case we need them to be released in legacy environments. 