### PR TITLE
fix: sjra-1397 Add check for ref character match in alt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Custom Java UDFs for [StarRocks](https://starrocks.io/), focused on genomics data transformation. Currently contains `VariantIdUDF`, which encodes genomic variants (SNV, deletion, micro-insertion) into 64-bit signed integers using bit-packing.
+Custom Java UDFs for [StarRocks](https://starrocks.io/), focused on genomics data transformation. Encodes genomic variants into 64-bit signed integers using bit-packing for fast joins/aggregations vs. string keys like `1-12345-A-T`.
+
+UDFs:
+- `VariantIdUDF` — SNV, deletion, micro-insertion (1 bp)
+- `CNVIdUDF` — copy-number variants (`<DEL>` / `<DUP>`)
+- `Utils.parseChromosome` — shared chromosome-string → int (1–25)
 
 ## Build Commands
 
@@ -20,17 +25,31 @@ Output JAR: `target/radiant-starrocks-udf-<version>-jar-with-dependencies.jar`
 ## Architecture
 
 - **Java 17**, Maven build, no runtime dependencies (standalone fat JAR for StarRocks)
-- **Single UDF pattern**: Each UDF class lives in `src/main/java/org/radiant/` and exposes a `public Long evaluate(...)` method that StarRocks calls directly
+- **Single UDF pattern**: each UDF class in `src/main/java/org/radiant/` exposes `public Long evaluate(...)` — StarRocks calls directly
 - **Tests**: JUnit 5 in `src/test/java/org/radiant/`, one test class per UDF
+- All UDFs return `null` on invalid/unsupported input — StarRocks treats null as "fall back to lookup table"
+- Chromosomes (`Utils.parseChromosome`): 1–22 numeric, X→23, Y→24, M/MT→25; else `-1`
+- Position bound: `start ∈ [1, 999_000_000]`
 
-### VariantIdUDF Encoding (63 useful bits + MSB flag)
+### VariantIdUDF — 64-bit layout
 
 ```
-| MSB=1 | chrom (5 bits) | start (30 bits) | alt (3 bits) | length (25 bits) |
+| MSB=1 | chrom (5) | start (30) | alt (3) | length (25) |
 ```
 
-- Chromosomes: 1-22 numeric, X→23, Y→24, M/MT→25
-- Returns `null` for any invalid or unsupported input (insertions >1bp, MNVs)
+- MSB=1 distinguishes UDF-encoded IDs from lookup-table IDs (MSB=0) sharing same column
+- `alt`: A=1, T=2, C=3, G=4 (SNV/micro-insertion only); 0 for deletions
+- `length`: deletion ref-length or 1 for micro-insertion; 0 for SNV; max 33,554,431 (25 bits)
+- Rejects: insertions >1 bp, MNVs, unknown bases
+
+### CNVIdUDF — 64-bit layout
+
+```
+| type (1) | chrom (5) | start (30) | length (28) |
+```
+
+- `type` MSB: 1 = LOSS (`<DEL>`), 0 = GAIN (`<DUP>`)
+- Only `<DEL>` / `<DUP>` accepted as `alt`
 
 ## CI/CD
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Output JAR: `target/radiant-starrocks-udf-<version>-jar-with-dependencies.jar`
 - MSB=1 distinguishes UDF-encoded IDs from lookup-table IDs (MSB=0) sharing same column
 - `alt`: A=1, T=2, C=3, G=4 (SNV/micro-insertion only); 0 for deletions
 - `length`: deletion ref-length or 1 for micro-insertion; 0 for SNV; max 33,554,431 (25 bits)
-- Rejects: insertions >1 bp, MNVs, unknown bases
+- Rejects: insertions >1 bp, MNVs, unknown bases, indel
 
 ### CNVIdUDF — 64-bit layout
 

--- a/README.md
+++ b/README.md
@@ -81,13 +81,14 @@ If the encoding exceeded 64 bits, comparisons would require multiple instruction
 
 ## 🧬 Supported Variant Types
 
-| Variant Type               | Example                             | Supported? | Notes                                      |
-|----------------------------|-------------------------------------|-------------|--------------------------------------------|
-| **SNV**                    | `1-12345-A-T`                       | ✅ | Fully supported.                           |
-| **Deletion**               | `1-12345-ATG-A`                     | ✅ | Any length deletion supported.             |
-| **Micro‑Insertion (1 bp)** | `1-12345-A-AT`                      | ✅ | Single‑base insertion only.                |
-| **Insertion >1 bp**        | `1-12345-A-ATG`                     | ❌ | Too large for encoding; handled by lookup. |
-| **Others chromosome**      | Others cromosome than 1-22, X, Y, M | ❌ | Too large for encoding; handled by lookup. |
+| Variant Type               | Example                             | Supported? | Notes                                       |
+|----------------------------|-------------------------------------|------------|---------------------------------------------|
+| **SNV**                    | `1-12345-A-T`                       | ✅          | Fully supported.                            |
+| **Deletion**               | `1-12345-ATG-A`                     | ✅          | Any length deletion supported.              |
+| **Micro‑Insertion (1 bp)** | `1-12345-A-AT`                      | ✅          | Single‑base insertion only.                 |
+| **Insertion >1 bp**        | `1-12345-A-ATG`                     | ❌          | Too large for encoding; handled by lookup.  |
+| **Others chromosome**      | Others cromosome than 1-22, X, Y, M | ❌          | Too large for encoding; handled by lookup.  |
+| **Indel**                  | `G` -> `TT`                         | ❌          | Special cases.                              | 
 
 **Note:**  
 Variants that are not supported by this encoding (e.g., insertions >1 bp or non-standard chromosomes) will result in a `NULL` return value.  

--- a/src/main/java/org/radiant/VariantIdUDF.java
+++ b/src/main/java/org/radiant/VariantIdUDF.java
@@ -30,11 +30,10 @@ public class VariantIdUDF {
         if (altLen == 1 && refLen == 1) {
             // SNV
             altCode = baseCode(alt.charAt(0));
-        } else if (altLen == 1 && refLen > 1) {
+        } else if (altLen == 1 && refLen > 1 && (alt.charAt(0) == ref.charAt(0))) {
             // Deletion
-            if (alt.charAt(0) != ref.charAt(0)) return null; // alt must match first base of ref
             lengthCode = refLen;
-        } else if (altLen == 2 && refLen == 1) {
+        } else if (altLen == 2 && refLen == 1 && (alt.charAt(0) == ref.charAt(0))) {
             // Micro-insertion
             altCode = baseCode(alt.charAt(1));
             lengthCode = 1;

--- a/src/test/java/org/radiant/VariantIdUDFTest.java
+++ b/src/test/java/org/radiant/VariantIdUDFTest.java
@@ -82,5 +82,127 @@ public class VariantIdUDFTest {
         assertNotNull(id);
         assertTrue(id < 0);
     }
+
+    @Test
+    public void testMicroInsertionAnchorMismatch() {
+        // alt[0] must match ref[0] — micro-insertion anchor base
+        assertNull(udf.evaluate("1", 100L, "A", "TG"));
+        assertNull(udf.evaluate("1", 100L, "G", "AT"));
+        assertNull(udf.evaluate("1", 100L, "C", "GA"));
+    }
+
+    @Test
+    public void testDeletionAnchorMismatch() {
+        // alt[0] must match ref[0] — deletion anchor base
+        assertNull(udf.evaluate("1", 100L, "ATG", "T"));
+        assertNull(udf.evaluate("1", 100L, "GCC", "C"));
+    }
+
+    @Test
+    public void testMicroInsertionAnchorMatch() {
+        // alt[0] == ref[0] — valid micro-insertion
+        assertNotNull(udf.evaluate("1", 100L, "A", "AT"));
+        assertNotNull(udf.evaluate("1", 100L, "G", "GC"));
+        assertNotNull(udf.evaluate("1", 100L, "C", "CA"));
+        assertNotNull(udf.evaluate("1", 100L, "T", "TG"));
+    }
+
+    @Test
+    public void testDeterminism() {
+        Long a = udf.evaluate("1", 12345L, "A", "T");
+        Long b = udf.evaluate("1", 12345L, "A", "T");
+        assertEquals(a, b);
+
+        Long c = udf.evaluate("X", 999L, "ATG", "A");
+        Long d = udf.evaluate("X", 999L, "ATG", "A");
+        assertEquals(c, d);
+    }
+
+    @Test
+    public void testDistinctVariantsDistinctIds() {
+        Long snv = udf.evaluate("1", 100L, "A", "T");
+        Long del = udf.evaluate("1", 100L, "AT", "A");
+        Long ins = udf.evaluate("1", 100L, "A", "AT");
+        Long otherChrom = udf.evaluate("2", 100L, "A", "T");
+        Long otherPos = udf.evaluate("1", 101L, "A", "T");
+        Long otherAlt = udf.evaluate("1", 100L, "A", "G");
+
+        assertNotEquals(snv, del);
+        assertNotEquals(snv, ins);
+        assertNotEquals(snv, otherChrom);
+        assertNotEquals(snv, otherPos);
+        assertNotEquals(snv, otherAlt);
+        assertNotEquals(del, ins);
+    }
+
+    @Test
+    public void testBitLayoutSnv() {
+        // Layout: | MSB=1 | chrom (5) | start (30) | alt (3) | length (25) |
+        // chrom=1, start=12345, alt=T(2), length=0
+        Long id = udf.evaluate("1", 12345L, "A", "T");
+        assertNotNull(id);
+        assertEquals(1L, (id >>> 63) & 0x1L);                   // MSB=1
+        assertEquals(1L, (id >>> 58) & 0x1FL);                  // chrom
+        assertEquals(12345L, (id >>> 28) & 0x3FFFFFFFL);        // start
+        assertEquals(2L, (id >>> 25) & 0x7L);                   // alt = T
+        assertEquals(0L, id & 0x1FFFFFFL);                      // length
+    }
+
+    @Test
+    public void testBitLayoutDeletion() {
+        // chrom=X(23), start=500, alt=0, length=3 (ref="ATG")
+        Long id = udf.evaluate("X", 500L, "ATG", "A");
+        assertNotNull(id);
+        assertEquals(1L, (id >>> 63) & 0x1L);
+        assertEquals(23L, (id >>> 58) & 0x1FL);
+        assertEquals(500L, (id >>> 28) & 0x3FFFFFFFL);
+        assertEquals(0L, (id >>> 25) & 0x7L);
+        assertEquals(3L, id & 0x1FFFFFFL);
+    }
+
+    @Test
+    public void testBitLayoutMicroInsertion() {
+        // chrom=Y(24), start=42, alt=G(4), length=1
+        Long id = udf.evaluate("Y", 42L, "C", "CG");
+        assertNotNull(id);
+        assertEquals(1L, (id >>> 63) & 0x1L);
+        assertEquals(24L, (id >>> 58) & 0x1FL);
+        assertEquals(42L, (id >>> 28) & 0x3FFFFFFFL);
+        assertEquals(4L, (id >>> 25) & 0x7L);
+        assertEquals(1L, id & 0x1FFFFFFL);
+    }
+
+    @Test
+    public void testAllChromosomes() {
+        for (int i = 1; i <= 22; i++) {
+            assertNotNull(udf.evaluate(String.valueOf(i), 1L, "A", "T"));
+        }
+        assertNotNull(udf.evaluate("X", 1L, "A", "T"));
+        assertNotNull(udf.evaluate("Y", 1L, "A", "T"));
+        assertNotNull(udf.evaluate("M", 1L, "A", "T"));
+        assertNotNull(udf.evaluate("MT", 1L, "A", "T"));
+    }
+
+    @Test
+    public void testAllSnvBases() {
+        assertNotNull(udf.evaluate("1", 1L, "A", "C"));
+        assertNotNull(udf.evaluate("1", 1L, "A", "G"));
+        assertNotNull(udf.evaluate("1", 1L, "A", "T"));
+        assertNotNull(udf.evaluate("1", 1L, "C", "A"));
+        assertNotNull(udf.evaluate("1", 1L, "G", "A"));
+        assertNotNull(udf.evaluate("1", 1L, "T", "A"));
+    }
+
+    @Test
+    public void testInvalidStart() {
+        assertNull(udf.evaluate("1", 0L, "A", "T"));
+        assertNull(udf.evaluate("1", -1L, "A", "T"));
+    }
+
+    @Test
+    public void testEmptyAllele() {
+        assertNull(udf.evaluate("1", 1L, "", "T"));
+        assertNull(udf.evaluate("1", 1L, "A", ""));
+    }
 }
 

--- a/src/test/java/org/radiant/VariantIdUDFTest.java
+++ b/src/test/java/org/radiant/VariantIdUDFTest.java
@@ -92,14 +92,14 @@ public class VariantIdUDFTest {
     }
 
     @Test
-    public void testDeletionAnchorMismatch() {
+    public void testDeletionIndel() {
         // alt[0] must match ref[0] — deletion anchor base
         assertNull(udf.evaluate("1", 100L, "ATG", "T"));
         assertNull(udf.evaluate("1", 100L, "GCC", "C"));
     }
 
     @Test
-    public void testMicroInsertionAnchorMatch() {
+    public void testInsertionIndel() {
         // alt[0] == ref[0] — valid micro-insertion
         assertNotNull(udf.evaluate("1", 100L, "A", "AT"));
         assertNotNull(udf.evaluate("1", 100L, "G", "GC"));


### PR DESCRIPTION
## 📌 Context

<!-- Briefly describe the purpose of this PR. Include any relevant context. -->

While performing ETL imports, a bug surfaced where different `locus_hash` yielded the same `locus_id. 

After investigation, the error was pinpointed to the UDF responsible for computing the `locus_id` based on the variants data. 

The following condition was not properly handled:

```
|reference|alternate|
+---------+---------+
|G        |TT       |
```

The above should have yield `null` but instead returned a valid `locus_id`, this caused an error downstream in the pipeline where `locus_hash` comparison failed (due to different values). 

## 📝 Changes

<!-- List the main changes in this PR. -->

- Add validation on the first character of the alternate, which needs to match the reference value.

## 🧪 Tests

<!-- Describe any new or updated tests, how to run them, and relevant results. -->

- Added additional tests to existing conditions and validated the new condition.

## 🔗 Related Issues

<!-- Link to any relevant GitHub issues, Jira tickets, etc. -->

- https://d3b.atlassian.net/browse/SJRA-1397